### PR TITLE
Add Unit Test for Models

### DIFF
--- a/jest.backend.config.js
+++ b/jest.backend.config.js
@@ -18,8 +18,9 @@ export default {
   collectCoverageFrom: [
     "controllers/**",
     "config/**",
+    "middlewares/**",
+    "models/**",
   ],
-  collectCoverageFrom: ["controllers/**", "middlewares/**", "config/**"],
   coverageThreshold: {
     global: {
       lines: 100,

--- a/models/categoryModel.js
+++ b/models/categoryModel.js
@@ -1,10 +1,10 @@
-import mongoose from "mongoose";
+import mongoose from 'mongoose';
 
 const categorySchema = new mongoose.Schema({
   name: {
     type: String,
-    // required: true,
-    // unique: true,
+    required: true,
+    unique: true,
   },
   slug: {
     type: String,
@@ -12,4 +12,4 @@ const categorySchema = new mongoose.Schema({
   },
 });
 
-export default mongoose.model("Category", categorySchema);
+export default mongoose.model('Category', categorySchema);

--- a/models/categoryModel.test.js
+++ b/models/categoryModel.test.js
@@ -41,6 +41,47 @@ describe('Category Model Test Suite', () => {
     expect(savedCategory.slug).toBe(validCategory.slug);
   });
 
+  it('should fail to save category without name', async () => {
+    const categoryWithoutName = new CategoryModel({
+      slug: 'test-category',
+    });
+
+    let err;
+    try {
+      await categoryWithoutName.save();
+    } catch (error) {
+      err = error;
+    }
+
+    expect(err).toBeInstanceOf(mongoose.Error.ValidationError);
+    expect(err.errors.name).toBeDefined();
+  });
+
+  it('should fail to save category with duplicate name', async () => {
+    // Save the first category
+    const firstCategory = new CategoryModel({
+      name: 'Test Category',
+      slug: 'test-category',
+    });
+    await firstCategory.save();
+
+    // Try to save another category with the same name
+    const duplicateCategory = new CategoryModel({
+      name: 'Test Category',
+      slug: 'test-category-2',
+    });
+
+    let err;
+    try {
+      await duplicateCategory.save();
+    } catch (error) {
+      err = error;
+    }
+
+    expect(err).toBeDefined();
+    expect(err.code).toBe(11000); // MongoDB duplicate key error code
+  });
+
   it('should convert slug to lowercase', async () => {
     const category = new CategoryModel({
       name: 'Test Category',

--- a/models/categoryModel.test.js
+++ b/models/categoryModel.test.js
@@ -1,0 +1,63 @@
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import CategoryModel from './categoryModel';
+
+let mongoServer;
+
+// Connect to the in-memory database before tests
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  const mongoUri = mongoServer.getUri();
+  await mongoose.connect(mongoUri);
+});
+
+// Clear all test data after each test
+afterEach(async () => {
+  const collections = mongoose.connection.collections;
+  for (const key in collections) {
+    const collection = collections[key];
+    await collection.deleteMany({});
+  }
+});
+
+// Disconnect and close the server after all tests
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+describe('Category Model Test Suite', () => {
+  it('should create & save category successfully', async () => {
+    const validCategory = {
+      name: 'Electronics',
+      slug: 'electronics',
+    };
+
+    const category = new CategoryModel(validCategory);
+    const savedCategory = await category.save();
+
+    expect(savedCategory._id).toBeDefined();
+    expect(savedCategory.name).toBe(validCategory.name);
+    expect(savedCategory.slug).toBe(validCategory.slug);
+  });
+
+  it('should convert slug to lowercase', async () => {
+    const category = new CategoryModel({
+      name: 'Test Category',
+      slug: 'TEST-CATEGORY',
+    });
+
+    const savedCategory = await category.save();
+    expect(savedCategory.slug).toBe('test-category');
+  });
+
+  it('should save category without slug', async () => {
+    const category = new CategoryModel({
+      name: 'Test Category',
+    });
+
+    const savedCategory = await category.save();
+    expect(savedCategory.name).toBe('Test Category');
+    expect(savedCategory.slug).toBeUndefined();
+  });
+});

--- a/models/orderModel.test.js
+++ b/models/orderModel.test.js
@@ -1,0 +1,147 @@
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import OrderModel from './orderModel';
+import ProductModel from './productModel';
+import UserModel from './userModel';
+import CategoryModel from './categoryModel';
+
+let mongoServer;
+
+// Connect to the in-memory database before tests
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  const mongoUri = mongoServer.getUri();
+  await mongoose.connect(mongoUri);
+});
+
+// Clear all test data after each test
+afterEach(async () => {
+  const collections = mongoose.connection.collections;
+  for (const key in collections) {
+    const collection = collections[key];
+    await collection.deleteMany({});
+  }
+});
+
+// Disconnect and close the server after all tests
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+describe('Order Model Test Suite', () => {
+  let testUser;
+  let testProduct;
+
+  beforeEach(async () => {
+    // Create a test user
+    const user = new UserModel({
+      name: 'Test User',
+      email: 'test@example.com',
+      password: 'password123',
+      phone: '1234567890',
+      address: { street: '123 Test St' },
+      answer: 'blue',
+    });
+    testUser = await user.save();
+
+    // Create a test category
+    const category = new CategoryModel({ name: 'Test Category' });
+    const testCategory = await category.save();
+
+    // Create a test product
+    const product = new ProductModel({
+      name: 'Test Product',
+      slug: 'test-product',
+      description: 'Test Description',
+      price: 99.99,
+      category: testCategory._id,
+      quantity: 100,
+    });
+    testProduct = await product.save();
+  });
+
+  it('should create & save order successfully', async () => {
+    const validOrder = {
+      products: [testProduct._id],
+      payment: { id: 'test_payment', amount: 99.99 },
+      buyer: testUser._id,
+      status: 'Not Process',
+    };
+
+    const order = new OrderModel(validOrder);
+    const savedOrder = await order.save();
+
+    expect(savedOrder._id).toBeDefined();
+    expect(savedOrder.products[0].toString()).toBe(testProduct._id.toString());
+    expect(savedOrder.payment).toEqual(validOrder.payment);
+    expect(savedOrder.buyer.toString()).toBe(testUser._id.toString());
+    expect(savedOrder.status).toBe('Not Process');
+    expect(savedOrder.createdAt).toBeDefined();
+    expect(savedOrder.updatedAt).toBeDefined();
+  });
+
+  it('should save order with default status', async () => {
+    const orderWithoutStatus = {
+      products: [testProduct._id],
+      payment: { id: 'test_payment', amount: 99.99 },
+      buyer: testUser._id,
+    };
+
+    const order = new OrderModel(orderWithoutStatus);
+    const savedOrder = await order.save();
+
+    expect(savedOrder.status).toBe('Not Process');
+  });
+
+  it('should fail to save order with invalid status', async () => {
+    const orderWithInvalidStatus = {
+      products: [testProduct._id],
+      payment: { id: 'test_payment', amount: 99.99 },
+      buyer: testUser._id,
+      status: 'Invalid Status',
+    };
+
+    let err;
+    try {
+      const order = new OrderModel(orderWithInvalidStatus);
+      await order.save();
+    } catch (error) {
+      err = error;
+    }
+
+    expect(err).toBeDefined();
+    expect(err.errors.status).toBeDefined();
+  });
+
+  it('should populate products and buyer', async () => {
+    const order = new OrderModel({
+      products: [testProduct._id],
+      payment: { id: 'test_payment', amount: 99.99 },
+      buyer: testUser._id,
+    });
+
+    await order.save();
+
+    const populatedOrder = await OrderModel.findById(order._id)
+      .populate('products')
+      .populate('buyer');
+
+    expect(populatedOrder.products[0].name).toBe('Test Product');
+    expect(populatedOrder.buyer.name).toBe('Test User');
+  });
+
+  it('should update order status', async () => {
+    const order = new OrderModel({
+      products: [testProduct._id],
+      payment: { id: 'test_payment', amount: 99.99 },
+      buyer: testUser._id,
+    });
+
+    const savedOrder = await order.save();
+    savedOrder.status = 'Processing';
+    const updatedOrder = await savedOrder.save();
+
+    expect(updatedOrder.status).toBe('Processing');
+  });
+});

--- a/models/productModel.test.js
+++ b/models/productModel.test.js
@@ -1,0 +1,146 @@
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import ProductModel from './productModel';
+import CategoryModel from './categoryModel';
+
+let mongoServer;
+
+// Connect to the in-memory database before tests
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  const mongoUri = mongoServer.getUri();
+  await mongoose.connect(mongoUri);
+});
+
+// Clear all test data after each test
+afterEach(async () => {
+  const collections = mongoose.connection.collections;
+  for (const key in collections) {
+    const collection = collections[key];
+    await collection.deleteMany({});
+  }
+});
+
+// Disconnect and close the server after all tests
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+describe('Product Model Test Suite', () => {
+  let testCategory;
+
+  beforeEach(async () => {
+    // Create a test category to use in product tests
+    const category = new CategoryModel({ name: 'Test Category' });
+    testCategory = await category.save();
+  });
+
+  it('should create & save product successfully', async () => {
+    const validProduct = {
+      name: 'Test Product',
+      slug: 'test-product',
+      description: 'Test Description',
+      price: 99.99,
+      category: testCategory._id,
+      quantity: 100,
+      shipping: true,
+    };
+
+    const product = new ProductModel(validProduct);
+    const savedProduct = await product.save();
+
+    expect(savedProduct._id).toBeDefined();
+    expect(savedProduct.name).toBe(validProduct.name);
+    expect(savedProduct.slug).toBe(validProduct.slug);
+    expect(savedProduct.description).toBe(validProduct.description);
+    expect(savedProduct.price).toBe(validProduct.price);
+    expect(savedProduct.category.toString()).toBe(testCategory._id.toString());
+    expect(savedProduct.quantity).toBe(validProduct.quantity);
+    expect(savedProduct.shipping).toBe(validProduct.shipping);
+    expect(savedProduct.createdAt).toBeDefined();
+    expect(savedProduct.updatedAt).toBeDefined();
+  });
+
+  it('should fail to save product with missing required fields', async () => {
+    const productWithMissingFields = new ProductModel({
+      name: 'Test Product',
+      // missing other required fields
+    });
+
+    let err;
+    try {
+      await productWithMissingFields.save();
+    } catch (error) {
+      err = error;
+    }
+
+    expect(err).toBeInstanceOf(mongoose.Error.ValidationError);
+    expect(err.errors.slug).toBeDefined();
+    expect(err.errors.description).toBeDefined();
+    expect(err.errors.price).toBeDefined();
+    expect(err.errors.category).toBeDefined();
+    expect(err.errors.quantity).toBeDefined();
+  });
+
+  it('should save product with photo', async () => {
+    const productWithPhoto = {
+      name: 'Test Product',
+      slug: 'test-product',
+      description: 'Test Description',
+      price: 99.99,
+      category: testCategory._id,
+      quantity: 100,
+      photo: {
+        data: Buffer.from('test image data'),
+        contentType: 'image/jpeg',
+      },
+    };
+
+    const product = new ProductModel(productWithPhoto);
+    const savedProduct = await product.save();
+
+    expect(savedProduct.photo.data).toBeDefined();
+    expect(savedProduct.photo.contentType).toBe('image/jpeg');
+  });
+
+  it('should save product without optional fields', async () => {
+    const productWithoutOptional = {
+      name: 'Test Product',
+      slug: 'test-product',
+      description: 'Test Description',
+      price: 99.99,
+      category: testCategory._id,
+      quantity: 100,
+      // shipping and photo are optional
+    };
+
+    const product = new ProductModel(productWithoutOptional);
+    const savedProduct = await product.save();
+
+    expect(savedProduct._id).toBeDefined();
+    expect(savedProduct.shipping).toBeUndefined();
+    expect(savedProduct.photo.data).toBeUndefined();
+    expect(savedProduct.photo.contentType).toBeUndefined();
+  });
+
+  it('should populate category field', async () => {
+    const product = new ProductModel({
+      name: 'Test Product',
+      slug: 'test-product',
+      description: 'Test Description',
+      price: 99.99,
+      category: testCategory._id,
+      quantity: 100,
+    });
+
+    await product.save();
+
+    const populatedProduct = await ProductModel.findById(product._id).populate(
+      'category'
+    );
+
+    expect(populatedProduct.category).toBeDefined();
+    expect(populatedProduct.category.name).toBe('Test Category');
+  });
+});

--- a/models/userModel.test.js
+++ b/models/userModel.test.js
@@ -1,0 +1,168 @@
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import UserModel from './userModel';
+
+let mongoServer;
+
+// Connect to the in-memory database before tests
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  const mongoUri = mongoServer.getUri();
+  await mongoose.connect(mongoUri);
+});
+
+// Clear all test data after each test
+afterEach(async () => {
+  const collections = mongoose.connection.collections;
+  for (const key in collections) {
+    const collection = collections[key];
+    await collection.deleteMany({});
+  }
+});
+
+// Disconnect and close the server after all tests
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+describe('User Model Test Suite', () => {
+  it('should create & save user successfully', async () => {
+    const validUser = {
+      name: 'John Doe',
+      email: 'johndoe@example.com',
+      password: 'password123',
+      phone: '1234567890',
+      address: {
+        street: '123 Main St',
+        city: 'Test City',
+        country: 'Test Country',
+      },
+      answer: 'blue',
+      role: 0,
+    };
+
+    const user = new UserModel(validUser);
+    const savedUser = await user.save();
+
+    // Object Id should be defined when successfully saved to MongoDB
+    expect(savedUser._id).toBeDefined();
+    expect(savedUser.name).toBe(validUser.name);
+    expect(savedUser.email).toBe(validUser.email);
+    expect(savedUser.password).toBe(validUser.password);
+    expect(savedUser.phone).toBe(validUser.phone);
+    expect(savedUser.address).toEqual(validUser.address);
+    expect(savedUser.answer).toBe(validUser.answer);
+    expect(savedUser.role).toBe(validUser.role);
+    expect(savedUser.createdAt).toBeDefined();
+    expect(savedUser.updatedAt).toBeDefined();
+  });
+
+  it('should fail to save user with missing required fields', async () => {
+    const userWithMissingFields = new UserModel({
+      name: 'John Doe',
+      // missing other required fields
+    });
+
+    let err;
+    try {
+      await userWithMissingFields.save();
+    } catch (error) {
+      err = error;
+    }
+
+    expect(err).toBeInstanceOf(mongoose.Error.ValidationError);
+    expect(err.errors.email).toBeDefined();
+    expect(err.errors.password).toBeDefined();
+    expect(err.errors.phone).toBeDefined();
+    expect(err.errors.address).toBeDefined();
+    expect(err.errors.answer).toBeDefined();
+  });
+
+  it('should fail to save user with duplicate email', async () => {
+    const userData = {
+      name: 'John Doe',
+      email: 'johndoe@example.com',
+      password: 'password123',
+      phone: '1234567890',
+      address: {
+        street: '123 Main St',
+      },
+      answer: 'blue',
+      role: 0,
+    };
+
+    // Save the first user
+    const firstUser = new UserModel(userData);
+    await firstUser.save();
+
+    // Try to save another user with the same email
+    const duplicateUser = new UserModel(userData);
+
+    let err;
+    try {
+      await duplicateUser.save();
+    } catch (error) {
+      err = error;
+    }
+
+    expect(err).toBeDefined();
+    expect(err.code).toBe(11000); // MongoDB duplicate key error code
+  });
+
+  it('should save user with default role value', async () => {
+    const userWithoutRole = {
+      name: 'Jane Doe',
+      email: 'janedoe@example.com',
+      password: 'password123',
+      phone: '1234567890',
+      address: {
+        street: '123 Main St',
+      },
+      answer: 'blue',
+      // role is not specified
+    };
+
+    const user = new UserModel(userWithoutRole);
+    const savedUser = await user.save();
+
+    expect(savedUser.role).toBe(0); // default value should be 0
+  });
+
+  it('should trim whitespace from name field', async () => {
+    const userWithWhitespace = {
+      name: '  John Doe  ',
+      email: 'johndoe@example.com',
+      password: 'password123',
+      phone: '1234567890',
+      address: {
+        street: '123 Main St',
+      },
+      answer: 'blue',
+    };
+
+    const user = new UserModel(userWithWhitespace);
+    const savedUser = await user.save();
+
+    expect(savedUser.name).toBe('John Doe'); // whitespace should be trimmed
+  });
+
+  it('should include timestamps in the document', async () => {
+    const userData = {
+      name: 'John Doe',
+      email: 'johndoe@example.com',
+      password: 'password123',
+      phone: '1234567890',
+      address: {
+        street: '123 Main St',
+      },
+      answer: 'blue',
+    };
+
+    const user = new UserModel(userData);
+    const savedUser = await user.save();
+
+    expect(savedUser.createdAt).toBeInstanceOf(Date);
+    expect(savedUser.updatedAt).toBeInstanceOf(Date);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "identity-obj-proxy": "^3.0.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
+        "mongodb-memory-server": "^10.1.4",
         "sonarqube-scanner": "^3.3.0"
       }
     },
@@ -2697,12 +2698,29 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/b4a": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
+      "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -2850,6 +2868,14 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.4.tgz",
+      "integrity": "sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true
     },
     "node_modules/basic-auth": {
       "version": "2.0.1",
@@ -3021,6 +3047,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16.20.1"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -3277,6 +3313,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -3998,6 +4041,13 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -4060,6 +4110,24 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+      }
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -4072,6 +4140,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/form-data": {
@@ -5954,6 +6043,95 @@
         "node": ">=18"
       }
     },
+    "node_modules/mongodb-memory-server": {
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-10.1.4.tgz",
+      "integrity": "sha512-+oKQ/kc3CX+816oPFRtaF0CN4vNcGKNjpOQe4bHo/21A3pMD+lC7Xz1EX5HP7siCX4iCpVchDMmCOFXVQSGkUg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "mongodb-memory-server-core": "10.1.4",
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
+    "node_modules/mongodb-memory-server-core": {
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-10.1.4.tgz",
+      "integrity": "sha512-o8fgY7ZalEd8pGps43fFPr/hkQu1L8i6HFEGbsTfA2zDOW0TopgpswaBCqDr0qD7ptibyPfB5DmC+UlIxbThzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-mutex": "^0.5.0",
+        "camelcase": "^6.3.0",
+        "debug": "^4.3.7",
+        "find-cache-dir": "^3.3.2",
+        "follow-redirects": "^1.15.9",
+        "https-proxy-agent": "^7.0.5",
+        "mongodb": "^6.9.0",
+        "new-find-package-json": "^2.0.0",
+        "semver": "^7.6.3",
+        "tar-stream": "^3.1.7",
+        "tslib": "^2.7.0",
+        "yauzl": "^3.1.3"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/mongoose": {
       "version": "8.9.6",
       "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.9.6.tgz",
@@ -6106,6 +6284,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/new-find-package-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/new-find-package-json/-/new-find-package-json-2.0.0.tgz",
+      "integrity": "sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=12.22.0"
       }
     },
     "node_modules/node-addon-api": {
@@ -6504,6 +6695,13 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -7397,6 +7595,20 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamx": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.0.tgz",
+      "integrity": "sha512-sLh1evHOzBy/iWRiR6d1zRcLao4gGZr3C1kzNz4fopCOKJb6xD9ub8Mpi9Mr1R6id5o43S+d93fI48UC5uM9aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      },
+      "optionalDependencies": {
+        "bare-events": "^2.2.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -7528,6 +7740,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/tar/node_modules/mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -7559,6 +7783,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/tmpl": {
@@ -8095,6 +8329,20 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.0.tgz",
+      "integrity": "sha512-Ow9nuGZE+qp1u4JIPvg+uCiUr7xGQWdff7JQSk5VGYTAZMDe2q8lxJ10ygv10qmSj031Ty/6FNJpLO4o1Sgc+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "pend": "~1.2.0"
+      },
       "engines": {
         "node": ">=12"
       }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "mongodb-memory-server": "^10.1.4",
     "sonarqube-scanner": "^3.3.0"
   }
 }


### PR DESCRIPTION
## Tests Added
- [x] `UserModel.test.js`
- [x] `ProductModel.test.js`
- [x] `OrderModel.test.js`
- [x] `CategoryModel.test.js`

Testing Mongoose models requires a slightly different approach than testing regular JavaScript functions since models interact with a database. I used MongoDB Memory Server to run a MongoDB in memory rather than using the actual instance of our DB.

The `mongodb-memory-server` package allows you to run MongoDB in memory for your tests without needing an actual MongoDB instance.

## Changes Made
Updated `name` field in `CategoryModel` to be `required` and `unique`